### PR TITLE
chore: Use java 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '25-ea'
+          java-version: '25'
           cache: 'maven'
       - name: Build with Maven
         run: ./mvnw --show-version --no-transfer-progress --errors --batch-mode package


### PR DESCRIPTION
Java 25 is now available from adoptium, no need to use the EA builds anymore